### PR TITLE
dep: update tinygo and proxy-wasm-go-sdk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ARCH := $(shell case $$(uname -m) in (x86_64) echo amd64 ;; (aarch64) echo arm64
 
 BIN_DIR := ./.bin
 
-TINYGO_VERSION := 0.28.1
+TINYGO_VERSION := 0.30.0
 TINYGO := $(abspath $(BIN_DIR)/tinygo-$(TINYGO_VERSION))/bin/tinygo
 
 DOCKER_NETWORK := proxy-wasm-http-cookie-header-convert_default
@@ -45,5 +45,5 @@ build-docker:
 		--volume "$(shell pwd):/workspace" \
 		--user "$(shell id -u):$(shell id -g)" \
 		--workdir /workspace \
-		golang:1.20.7-bookworm \
+		golang:1.21.5-bookworm \
 		make build

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/kauche/proxy-wasm-http-cookie-header-convert
 
-go 1.20
+go 1.21
 
-require github.com/tetratelabs/proxy-wasm-go-sdk v0.22.0
+require github.com/tetratelabs/proxy-wasm-go-sdk v0.22.1-0.20231016231553-1b9daaf70730

--- a/go.sum
+++ b/go.sum
@@ -2,9 +2,9 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
-github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/tetratelabs/proxy-wasm-go-sdk v0.22.0 h1:kS7BvMKN+FiptV4pfwiNX8e3q14evxAWkhYbxt8EI1M=
-github.com/tetratelabs/proxy-wasm-go-sdk v0.22.0/go.mod h1:qkW5MBz2jch2u8bS59wws65WC+Gtx3x0aPUX5JL7CXI=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/tetratelabs/proxy-wasm-go-sdk v0.22.1-0.20231016231553-1b9daaf70730 h1:z4seiwCKuO/PIX/suB8MAbizRT5n+QK5Cg7U7qEJaqw=
+github.com/tetratelabs/proxy-wasm-go-sdk v0.22.1-0.20231016231553-1b9daaf70730/go.mod h1:ONJBpAT76cj5X8ysJAkOdLKR/9jXgSTniWG+NGey7Yg=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/kauche/proxy-wasm-http-cookie-header-convert/test
 
-go 1.20
+go 1.21
 
 require github.com/110y/echoserver v0.0.0-20220824054727-f836f620659a
 


### PR DESCRIPTION
- Update to tinygo 0.30.0
- Update proxy-wasm-go-sdk to the latest main branch